### PR TITLE
Fix: fail if mail_dir is NOT a string

### DIFF
--- a/nullsmtp/nullsmtp.py
+++ b/nullsmtp/nullsmtp.py
@@ -38,7 +38,7 @@ class NullSMTP(smtpd.SMTPServer):
         smtpd.SMTPServer.__init__(self, localaddr, None)
 
         self.logger = get_logger()
-        if mail_dir is None or isinstance(mail_dir, str):
+        if mail_dir is None or not isinstance(mail_dir, str):
             msg = "Invalid mail_dir variable: {}".format(mail_dir)
             self.logger.error(msg)
             raise SystemExit(msg)


### PR DESCRIPTION
I encountered this issue when installing and running nullsmtp for the
first time:

    Invalid mail_dir variable: /home/pavel/.nullsmtp
    Invalid mail_dir variable: /home/pavel/.nullsmtp

This is probably not what we want; and this PR aims to remedy this.